### PR TITLE
Update rmats2sashimiplot.py

### DIFF
--- a/src/rmats2sashimiplot/rmats2sashimiplot.py
+++ b/src/rmats2sashimiplot/rmats2sashimiplot.py
@@ -508,9 +508,12 @@ def create_chr_aware_events_file(options):
     new_events_file_path = os.path.join(options.sashimi_path, 'events_file.txt')
     first_bam_path = options.b1.split(',')[0]
     tmp_sam_file_path = os.path.join(options.sashimi_path, 'tmp_chr_check.sam')
+
     with open(tmp_sam_file_path, 'wt') as tmp_sam_file_handle:
-        subprocess.check_call(['samtools', 'view', first_bam_path],
-                              stdout=tmp_sam_file_handle)
+        p1 = subprocess.Popen(['samtools', 'view', first_bam_path],
+                              stdout=subprocess.PIPE)
+        p2 = subprocess.Popen(['head'], stdin=p1.stdout, stdout=subprocess.PIPE)
+        tmp_sam_file_handle.write(p2.communicate()[0])
 
     with open(tmp_sam_file_path, 'rt') as tmp_sam_file_handle:
         first_line_of_sam = tmp_sam_file_handle.readline().rstrip('\n')


### PR DESCRIPTION
The `create_chr_aware_events_file()` function converts entire bam file to sam file.
This process is very time consuming, so I changed it to output only the first 6 lines.