### PR TITLE
Add options to control removal of 'chr' from events file

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ usage: rmats2sashimiplot [-h] --l1 L1 --l2 L2 -o OUT_DIR
                          [--group-info GROUP_INFO] [--min-counts MIN_COUNTS]
                          [--color COLOR] [--font-size FONT_SIZE]
                          [--hide-number] [--no-text-background]
+                         [--keep-event-chr-prefix] [--remove-event-chr-prefix]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -226,6 +227,12 @@ Optional:
                         Set the font size. Default: 8
   --hide-number         Do not display the read count on the junctions
   --no-text-background  Do not put a white box behind the junction read count
+  --keep-event-chr-prefix
+                        force the contig name in the provided events file to
+                        be used
+  --remove-event-chr-prefix
+                        remove any leading "chr" from contig names in the
+                        provided events file
 ```
 
 ## Output

--- a/src/rmats2sashimiplot/rmats2sashimiplot.py
+++ b/src/rmats2sashimiplot/rmats2sashimiplot.py
@@ -537,6 +537,9 @@ def create_chr_aware_events_file(options):
             sam_has_chr_prefix = ref_name.startswith('chr')
             break  # only check first alignment
 
+    remove_chr_prefix = (not options.keep_event_chr_prefix
+                         and (options.remove_event_chr_prefix
+                              or not sam_has_chr_prefix))
     with open(orig_events_file_path, 'rt') as orig_handle:
         with open(new_events_file_path, 'wt') as new_handle:
             for i, line in enumerate(orig_handle):
@@ -545,7 +548,7 @@ def create_chr_aware_events_file(options):
 
                 if is_header_line:
                     chr_index = columns.index('chr')
-                elif not sam_has_chr_prefix:
+                elif remove_chr_prefix:
                     orig_chr_column = columns[chr_index]
                     if orig_chr_column.startswith('chr'):
                         columns[chr_index] = orig_chr_column[3:]
@@ -855,6 +858,13 @@ def main():
     optional_group.add_argument(
         "--no-text-background", dest="text_background", action="store_false",
         help='Do not put a white box behind the junction read count')
+    optional_group.add_argument(
+        "--keep-event-chr-prefix", action="store_true",
+        help='force the contig name in the provided events file to be used')
+    optional_group.add_argument(
+        "--remove-event-chr-prefix", action="store_true",
+        help=('remove any leading "chr" from contig names in the provided'
+              ' events file'))
 
     options = parser.parse_args()
     out_path = os.path.abspath(os.path.expanduser(options.out_dir))


### PR DESCRIPTION
In response to https://github.com/Xinglab/rmats2sashimiplot/issues/64