### PR TITLE
Parse --min-counts as an int

### DIFF
--- a/src/rmats2sashimiplot/rmats2sashimiplot.py
+++ b/src/rmats2sashimiplot/rmats2sashimiplot.py
@@ -899,7 +899,7 @@ def main():
               ' sashimi plot will be generated for each group instead of'
               ' the default behavior of one plot per replicate'))
     optional_group.add_argument(
-        "--min-counts", dest="min_counts", default=0,
+        "--min-counts", dest="min_counts", default=0, type=int,
         help=("Individual junctions with read count below --min-counts will"
               " be omitted from the plot. Default: %(default)s"))
     optional_group.add_argument(


### PR DESCRIPTION
Addresses https://github.com/Xinglab/rmats2sashimiplot/issues/91

The error did not happen in python2 which allowed comparing `str` and `int`