### PR TITLE
Fix a FixedFormatter/FixedLocator warning (matplotlib)

### DIFF
--- a/src/MISO/misopy/sashimi_plot/plot_utils/plot_gene.py
+++ b/src/MISO/misopy/sashimi_plot/plot_utils/plot_gene.py
@@ -451,10 +451,10 @@ def plot_density(sashimi_obj, pickle_filename, event, plot_title=None, group_inf
                         curr_yticklabels.append("%.1f" %(label))
                     else:
                         curr_yticklabels.append("%d" %(label))
+            curr_ax.set_yticks(universal_yticks)
             curr_ax.set_yticklabels(curr_yticklabels,
                                     fontsize=font_size)
             curr_ax.spines["left"].set_bounds(0, max_used_yval)
-            curr_ax.set_yticks(universal_yticks)
             curr_ax.yaxis.set_ticks_position('left')
             curr_ax.spines["right"].set_color('none')
             if show_ylabel:


### PR DESCRIPTION
This PR fix a warning message produced during the creation of the Sashimi plots.

```
UserWarning: FixedFormatter should only be used together with FixedLocator
```

The fix is simple, simply adjust and place `set_yticks()` before `set_yticklabels` will do.